### PR TITLE
Should match any line ending

### DIFF
--- a/lib/linter-pyflakes.coffee
+++ b/lib/linter-pyflakes.coffee
@@ -16,7 +16,7 @@ class LinterPyflakes extends Linter
 
   # A regex pattern used to extract information from the executable's output.
   # regex: ""/path/to/python/file.py:28: redefinition of unused 'models' from line 5"
-  regex: ':(?<line>\\d+): (?<message>.*?)\n'
+  regex: ':(?<line>\\d+): (?<message>.*?)[\r\n]+'
 
   constructor: (editor)->
     super editor


### PR DESCRIPTION
The existing regex doesn't match Windows line endings.

Since the dot character [doesn't match on line-ending characters](http://www.regular-expressions.info/dot.html), there is never a match.

While I believe this change is pretty innocuous, I don't have a linux environment that can run Atom, so I can't be 100% sure that this is working on Linux.