### PR TITLE
update contributing to mention running tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,16 +2,10 @@
 
 If you would like to contribute enhancements or fixes, please do the following:
 
-1.  Fork the plugin repository.
-2.  Hack on a separate topic branch created from the latest `master`.
-3.  Commit and push the topic branch.
-4.  Make a pull request.
-5.  Welcome to the club!
-
-Please note that modications should follow these coding guidelines:
-
--   Indent is 2 spaces.
--   Code should pass coffeelint linter.
--   Vertical whitespace helps readability, don’t be afraid to use it.
+- Fork the plugin repository.
+- Hack on a separate topic branch created from the latest `master`.
+- Commit and push the topic branch.
+- Make sure the tests pass: `apm test`
+- Make a pull request.
 
 Thank you for helping out!


### PR DESCRIPTION
Mention `apm test` which now covers `coffeelint`.