### PR TITLE
choose marker type based on pyflakes message

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -15,13 +15,13 @@ module.exports =
       grammarScopes: ['source.python']
       scope: 'file'
       lintOnFly: true
-      lint: (textEditor) ->
+      lint: (textEditor) =>
         helpers ?= require('atom-linter')
         filePath = textEditor.getPath()
 
         return helpers.exec(atom.config.get(
           'linter-pyflakes.pyflakesExecutablePath'
-        ), [], {stdin: textEditor.getText(), stream: 'both'}).then (result) ->
+        ), [], {stdin: textEditor.getText(), stream: 'both'}).then (result) =>
           toReturn = []
 
           if result.stderr
@@ -41,10 +41,20 @@ module.exports =
             while (match = regex.exec(result.stdout)) isnt null
               line = parseInt(match[1]) or 0
               toReturn.push({
-                type: 'Warning'
+                type: @getMessageType(match[2])
                 text: match[2]
                 filePath
                 # make range the full line
                 range: helpers.rangeFromLineNumber(textEditor, line - 1)
               })
           return toReturn
+
+  getMessageType: (line) ->
+    if (
+      line.indexOf('used') isnt -1 or
+      line.indexOf('redefines') isnt -1 or
+      line.indexOf('shadowed') isnt -1 or
+      line.indexOf('may be') isnt -1
+    )
+      return 'Warning'
+    return 'Error'

--- a/spec/linter-pyflakes-spec.coffee
+++ b/spec/linter-pyflakes-spec.coffee
@@ -23,21 +23,15 @@ describe 'The pyflakes provider for Linter', ->
       return atom.workspace.open(__dirname + '/fixtures/invalid.py').then (editor) ->
         return lint(editor).then (messages) ->
           expect(messages.length).toEqual 2
-          expect(messages[0].range[0][0]).toEqual 0
-          expect(messages[0].range[0][1]).toEqual 0
-          expect(messages[0].range[1][0]).toEqual 0
-          expect(messages[0].range[1][1]).toEqual 9
-          expect(messages[1].range[0][0]).toEqual 4
-          expect(messages[1].range[0][1]).toEqual 4
-          expect(messages[1].range[1][0]).toEqual 4
-          expect(messages[1].range[1][1]).toEqual 22
+          expect(messages[0].range).toEqual [[0, 0], [0, 9]]
+          expect(messages[0].type).toEqual 'Warning'
+          expect(messages[1].range).toEqual [[4, 4], [4, 22]]
+          expect(messages[1].type).toEqual 'Error'
 
   it 'finds something wrong with invalid syntax', ->
     waitsForPromise ->
       return atom.workspace.open(__dirname + '/fixtures/invalid_syntax.py').then (editor) ->
         return lint(editor).then (messages) ->
           expect(messages.length).toEqual 1
-          expect(messages[0].range[0][0]).toEqual 0
-          expect(messages[0].range[0][1]).toEqual 7
-          expect(messages[0].range[1][0]).toEqual 0
-          expect(messages[0].range[1][1]).toEqual 7
+          expect(messages[0].range).toEqual [[0, 7], [0, 7]]
+          expect(messages[0].type).toEqual 'Error'


### PR DESCRIPTION
Instead of classifying all non-syntax errors as "Warnings" some messages are classified as "Warnings" while others are marked as "Errors".