### PR TITLE
Update CI Configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,28 @@
+### Project specific config ###
+language: python
+
+os:
+  - linux
+
+env:
+  matrix:
+    - ATOM_CHANNEL=stable
+    - ATOM_CHANNEL=beta
+
+install:
+  - pip install pyflakes
+
+### Generic setup follows ###
+script:
+  - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+  - chmod u+x build-package.sh
+  - ./build-package.sh
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+
 branches:
   only:
     - master
@@ -5,33 +30,12 @@ branches:
 git:
   depth: 10
 
-matrix:
-  include:
-    - os: linux
-      language: python
-      env: ATOM_CHANNEL=stable
-    - os: linux
-      language: python
-      env: ATOM_CHANNEL=beta
-    - os: osx
-      language: generic
-      env: ATOM_CHANNEL=stable
-      before_install:
-        - brew update
-        - brew install python
-    - os: osx
-      language: generic
-      env: ATOM_CHANNEL=beta
-      before_install:
-        - brew update
-        - brew install python
+sudo: false
 
-install:
-  - pip install pyflakes
-
-script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
-
-notifications:
-  email:
-    on_success: never
-    on_failure: change
+addons:
+  apt:
+    packages:
+    - build-essential
+    - git
+    - libgnome-keyring-dev
+    - fakeroot

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,30 +1,27 @@
-version: "{build}"
-
-platform: x64
-
-branches:
-    only:
-      - master
-
-clone_depth: 10
-
-skip_tags: true
+### Project specific config ###
+install:
+  - C:/Python35/Scripts/pip.exe install pyflakes
+  - "SET PATH=C:/Python35;C:/Python35/Scripts;%PATH%"
 
 environment:
-  APM_TEST_PACKAGES:
+  ATOM_LINT_WITH_BUNDLED_NODE: "true"
 
   matrix:
   - ATOM_CHANNEL: stable
   - ATOM_CHANNEL: beta
 
-install:
-  - ps: Install-Product node 5
-
-  - C:/Python35/Scripts/pip.exe install pyflakes
-  - "SET PATH=C:/Python35;C:/Python35/Scripts;%PATH%"
-
+### Generic setup follows ###
 build_script:
+  - pyflakes --version
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/atom/ci/master/build-package.ps1'))
 
+branches:
+  only:
+    - master
+
+version: "{build}"
+platform: x64
+clone_depth: 10
+skip_tags: true
 test: off
 deploy: off


### PR DESCRIPTION
Travis-CI:
* Remove macOS testing due to unusably long queue times
* Bugfixes to the script from atom/ci

AppVeyor:
* Stop installing Node.js v5 for no reason
* Show the version of pyflakes